### PR TITLE
Add build automation scripts

### DIFF
--- a/scripts/build.bat
+++ b/scripts/build.bat
@@ -1,0 +1,43 @@
+@echo off && setlocal EnableDelayedExpansion
+cd /d "%~dp0"
+cd ..
+
+set /a errorno=1
+for /F "delims=#" %%E in ('"prompt #$E# & for %%E in (1) do rem"') do set "_ESC=%%E"
+
+set "vswhere=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
+if not exist "!vswhere!" (
+  echo Failed to find "vswhere.exe".  Please install the latest version of Visual Studio.
+  goto :ERROR
+)
+
+set "vsdir="
+for /f "usebackq tokens=*" %%i in (
+  `"!vswhere!" -latest ^
+               -products * ^
+               -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 ^
+               -property installationPath`
+) do (
+  set "vsdir=%%i"
+)
+if "%vsdir%" == "" (
+  echo Failed to find Visual C++.  Please install the latest version of Visual C++.
+  goto :ERROR
+)
+
+call "!vsdir!\VC\Auxiliary\Build\vcvarsall.bat" x64 || goto :ERROR
+
+for %%i in (*.sln) do (
+  echo msbuild "%%i"
+  msbuild "%%i" /nologo /v:minimal /m /p:Configuration=Release /p:Platform=x64 /t:Clean,Build || goto :ERROR
+)
+
+echo %_ESC%[2K %~n0 : Status =%_ESC%[92m OK %_ESC%[0m
+set /a errorno=0
+goto :END
+
+:ERROR
+echo %_ESC%[2K %~n0 : Status =%_ESC%[92m ERROR %_ESC%[0m
+
+:END
+exit /B %errorno%

--- a/scripts/clean.bat
+++ b/scripts/clean.bat
@@ -1,0 +1,12 @@
+@echo off && setlocal EnableDelayedExpansion
+cd /d "%~dp0"
+cd ..
+
+for /F "delims=#" %%E in ('"prompt #$E# & for %%E in (1) do rem"') do set "_ESC=%%E"
+
+rmdir /s /q x64 2>nul
+rmdir /s /q .vs 2>nul
+
+del *.vcxproj.user 2>nul
+
+echo %_ESC%[2K %~n0 : Status =%_ESC%[92m OK %_ESC%[0m

--- a/scripts/clean.bat
+++ b/scripts/clean.bat
@@ -6,6 +6,7 @@ for /F "delims=#" %%E in ('"prompt #$E# & for %%E in (1) do rem"') do set "_ESC=
 
 rmdir /s /q x64 2>nul
 rmdir /s /q .vs 2>nul
+rmdir /s /q minimal_gl 2>nul
 
 del *.vcxproj.user 2>nul
 

--- a/scripts/make-release-archive.bat
+++ b/scripts/make-release-archive.bat
@@ -1,0 +1,60 @@
+@echo off && setlocal EnableDelayedExpansion
+
+:
+set /a _E =0 &&   set "_P=Build"
+:
+set /a _E+=1 &&   call "%~dp0build.bat" || goto :ERROR
+
+
+:
+set /a _E =0 &&   set "_P=Retrieve date, time and build-suffix"
+:
+set /a _E+=1 &&   cd /d "%~dp0"
+set /a _E+=1 &&   cd ..
+set /a _E+=1 &&   set /a errorno=1
+set /a _E+=1 &&   for /F "delims=#" %%E in ('"prompt #$E# & for %%E in (1) do rem"') do set "_ESC=%%E"
+set /a _E+=1 &&   for /f "tokens=2 delims==" %%a in ('wmic OS Get localdatetime /value') do set "dt=%%a"
+set /a _E+=1 &&   set "YYYY=%dt:~0,4%" & set "MM=%dt:~4,2%" & set "DD=%dt:~6,2%"
+set /a _E+=1 &&   set "Hour=%dt:~8,2%" & set "Min=%dt:~10,2%" & set "Sec=%dt:~12,2%"
+set /a _E+=1 &&   set "build_suffix=build_!YYYY!_!MM!_!DD!"
+set /a _E+=1 &&   set "arcname=minimal_gl.!build_suffix!.zip"
+
+
+:
+set /a _E =0 &&   set "_P=Setup staging directory for release archive"
+:
+set /a _E+=1 &&   if exist staging ( rmdir /S /Q staging 2>nul )                      || goto :ERROR
+set /a _E+=1 &&   mkdir staging\minimal_gl                                            || goto :ERROR
+set /a _E+=1 &&   mkdir staging\minimal_gl\examples                                   || goto :ERROR
+set /a _E+=1 &&   copy x64\Release\minimal_gl.exe staging\minimal_gl\                 || goto :ERROR
+set /a _E+=1 &&   copy examples\*.*               staging\minimal_gl\examples         || goto :ERROR
+set /a _E+=1 &&   ren staging\minimal_gl\minimal_gl.exe minimal_gl.!build_suffix!.exe || goto :ERROR
+
+
+:
+set /a _E =0 &&   set "_P=Create release archive with %windir%\tar.exe"
+:
+set /a _E+=1 &&   tar.exe -a -cf !arcname! -C staging minimal_gl || goto :ERROR
+
+
+:
+set /a _E =0 &&   set "_P=Delete staging directory"
+:
+set /a _E+=1 &&   rmdir /S /Q staging 2>nul || goto :ERROR
+
+
+:
+set /a _E =0 &&   set "_P=Clean"
+:
+set /a _E+=1 &&   call "%~dp0clean.bat" || goto :ERROR
+
+
+echo !_ESC![2K %~n0 : Status =!_ESC![92m OK !_ESC![0m
+set /a errorno=0
+goto :END
+
+:ERROR
+echo !_ESC![2K %~n0 : Status =!_ESC![92m ERROR !_ESC![0m, _P=!_P!, _E=!_E!
+
+:END
+exit /B %errorno%


### PR DESCRIPTION
以下のちょっとしたスクリプトを追加します
- `scripts/build.bat` : minimal_gl.exeのビルド
- `scripts/clean.bat` : `x64/` など中間ファイル用のディレクトリを削除
- `scripts/make-release-archive.bat` : 新しいリリース用の .zip アーカイブを生成
  - 内部では、以下を実行
    -  `scripts/build.bat` 呼び出し
    - `staging/` 下にアーカイブの構造を作る
    - Windows 付属の `tar.exe` で `staging/` から .zip アーカイブを生成
    - `scripts/clean.bat`で後始末

実験方法

```bat
cmd.exe
cd /d "%PUBLIC%"
git clone https://github.com/t-mat/minimal_gl.git
cd minimal_gl
.\scripts\make-release-archive.bat
dir *.zip
```
