### PR TITLE
fix: Fix trivial clang-cl warnings and errors

### DIFF
--- a/src/app.cpp
+++ b/src/app.cpp
@@ -61,7 +61,7 @@ static struct Camera {
 	float fovYInRadians;
 	float mat4x4CameraInWorld[4][4];
 	float mat4x4PrevCameraInWorld[4][4];
-} s_camera = {0};
+} s_camera = {{0}};
 static CaptureScreenShotSettings s_captureScreenShotSettings = {
 	/* char fileName[MAX_PATH]; */	{0},
 	/* int xReso; */				DEFAULT_SCREEN_XRESO,
@@ -595,7 +595,7 @@ SwapInterval AppRenderSettingsGetSwapIntervalControl(){
 /*=============================================================================
 ▼	ユーザーテクスチャ関連
 -----------------------------------------------------------------------------*/
-static char s_currentUserTextureFileName[NUM_USER_TEXTURES][MAX_PATH] = {0};
+static char s_currentUserTextureFileName[NUM_USER_TEXTURES][MAX_PATH] = {{0}};
 
 bool AppUserTexturesLoad(int userTextureIndex, const char *fileName){
 	if (userTextureIndex < 0 || NUM_USER_TEXTURES <= userTextureIndex) return false;
@@ -915,7 +915,7 @@ void AppExportExecutable(){
 	if (s_soundCreateShaderSucceeded
 	&&	s_graphicsCreateShaderSucceeded
 	) {
-		bool ret = ExportExecutable(
+		(void) ExportExecutable(
 			s_graphicsShaderCode,
 			s_soundShaderCode,
 			&s_renderSettings,
@@ -976,7 +976,7 @@ void AppRecordImageSequence(){
 	if (s_soundCreateShaderSucceeded
 	&&	s_graphicsCreateShaderSucceeded
 	) {
-		bool ret = RecordImageSequence(
+		(void) RecordImageSequence(
 			&s_renderSettings,
 			&s_recordImageSequenceSettings
 		);

--- a/src/dds_parser.cpp
+++ b/src/dds_parser.cpp
@@ -13,9 +13,6 @@ static int IntMax(int x, int y){
 static int IntCeilAlign(int x, int align){
 	return (x + (align - 1)) & ~(align - 1);
 }
-static size_t SizeTypeCeilAlign(size_t x, size_t align){
-	return (x + (align - 1)) & ~(align - 1);
-}
 
 static const int s_tblNumBitsPerPixel[] = {
 	/* DxgiFormat_Unknown */				0,

--- a/src/graphics.cpp
+++ b/src/graphics.cpp
@@ -15,16 +15,16 @@
 #define USER_TEXTURE_START_INDEX				(8)
 #define BUFFER_INDEX_FOR_SOUND_VISUALIZER_INPUT	(0)
 
-static GLuint s_mrtTextures[2 /* 裏表 */][NUM_RENDER_TARGETS] = {0};
+static GLuint s_mrtTextures[2 /* 裏表 */][NUM_RENDER_TARGETS] = {{0}};
 static GLuint s_mrtFrameBuffer = 0;
 static struct {
 	GLenum target;
 	GLuint id;
-} s_userTextures[NUM_USER_TEXTURES] = {0};
+} s_userTextures[NUM_USER_TEXTURES] = {{0}};
 static GLuint s_shaderPipelineId = 0;
 static GLuint s_vertexShaderId = 0;
 static GLuint s_fragmentShaderId = 0;
-static RenderSettings s_currentRenderSettings = {0};
+static RenderSettings s_currentRenderSettings = {(PixelFormat)0};
 static int s_xReso = DEFAULT_SCREEN_XRESO;
 static int s_yReso = DEFAULT_SCREEN_YRESO;
 

--- a/src/record_image_sequence.cpp
+++ b/src/record_image_sequence.cpp
@@ -223,7 +223,7 @@ static bool QueueInitialize(int numWorkers, int numJobs){
 
 static bool QueueTerminate(){
 	for (int i = 0; i < s_queue.numWorkers; i++) {
-		Job job = {0};
+		Job job = {{0}};
 		Enqueue(&job);	/* end mark */
 	}
 

--- a/src/sound.cpp
+++ b/src/sound.cpp
@@ -22,7 +22,6 @@ static bool s_paused = false;
 static GLuint s_soundShaderId = 0;
 static GLuint s_soundOutputSsbo = 0;
 static SOUND_SAMPLE_TYPE *s_mappedSoundOutputSsbo = NULL;
-static bool s_soundShaderSetupSucceeded = false;
 
 
 static int s_soundCurrentPartitionIndex = 0;
@@ -32,7 +31,7 @@ typedef enum {
 	PartitionState_Copied,
 	PartitionState_Synthesized,
 } PartitionState;
-static PartitionState s_soundBufferPartitionStates[NUM_SOUND_BUFFER_PARTITIONS] = {0};
+static PartitionState s_soundBufferPartitionStates[NUM_SOUND_BUFFER_PARTITIONS] = {(PartitionState)0};
 static uint32_t s_soundBufferPartitionSynthesizedFrameCount[NUM_SOUND_BUFFER_PARTITIONS] = {0};
 static SOUND_SAMPLE_TYPE s_soundBuffer[(NUM_SOUND_BUFFER_SAMPLES + NUM_SOUND_MARGIN_SAMPLES) * NUM_SOUND_CHANNELS];
 static HWAVEOUT s_waveOutHandle = 0;
@@ -67,7 +66,7 @@ static WAVEHDR s_waveHeader = {
 /* 再生位置取得用 */
 static MMTIME s_mmTime = {
 	TIME_SAMPLES,	/* win32 SDK で定義された定数 */
-	0
+	{0}
 };
 
 /*=============================================================================


### PR DESCRIPTION
- Add braces around sub-object initializer.
- Add explicit cast operator for object initializer.
- Add explicit `(void)` to indicate ignoring the return value.
- Remove unused functions and variables.

[`clang-cl`](https://learn.microsoft.com/en-us/cpp/build/clang-support-msbuild) によるビルドを試行した際に出る、些細なエラーおよび警告を修正します。

再現および修正手順は下記の通りです

<details><summary>修正手順</summary>

minimal_gl.sln を開いた後、以下の設定により clang-cl を選択

- Visual Studio Menu > Project > Properties > ダイアログオープン
- ダイアログ > minimal_gl Property Pages
  - 左ペイン > Configuration Properties > General
  - 右ペイン > Platform Toolset > LLVM (clang-cl)
  - 右下 Apply ボタン

以下を実行してビルド

Visual Studio Menu > Build > Build Solution

以下の警告が出る

```
1>src\app.cpp(64,15): warning : suggest braces around initialization of subobject [-Wmissing-braces]
1>src\app.cpp(598,74): warning : suggest braces around initialization of subobject [-Wmissing-braces]
1>src\app.cpp(918,8): warning : unused variable 'ret' [-Wunused-variable]
1>src\app.cpp(979,8): warning : unused variable 'ret' [-Wunused-variable]
1>src\graphics.cpp(18,68): warning : suggest braces around initialization of subobject [-Wmissing-braces]
1>src\graphics.cpp(23,40): warning : suggest braces around initialization of subobject [-Wmissing-braces]
```

適宜修正し、再度ビルドすると、以下のエラー及び警告が出る

```
1>src\dds_parser.cpp(16,15): warning : unused function 'SizeTypeCeilAlign' [-Wunused-function]
1>src\graphics.cpp(27,50): error : cannot initialize a member subobject of type 'PixelFormat' with an rvalue of type 'int'
```

適宜修正し、再度ビルドすると、以下のエラー及び警告が出る

```
1>src\record_image_sequence.cpp(226,14): warning : suggest braces around initialization of subobject [-Wmissing-braces]
1>src\sound.cpp(35,84): error : cannot initialize an array element of type 'PartitionState' with an rvalue of type 'int'
1>src\sound.cpp(70,2): warning : suggest braces around initialization of subobject [-Wmissing-braces]
```

適宜修正し、再度ビルドすると、以下の警告が出る

```
1>src\sound.cpp(25,13): warning : unused variable 's_soundShaderSetupSucceeded' [-Wunused-variable]
```

適宜修正し、再度ビルドすると、正常にビルドが完了する。

</details>
