### PR TITLE
Add GitHub-Actions scripts for push and tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,27 @@
+name: release
+
+on: push
+
+jobs:
+  build:
+    name: Build release
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # https://github.com/actions/checkout v4.2.2
+
+      - name: Build Artifacts
+        run: cmd.exe /c '.\scripts\make-artifacts.bat'
+
+      - name: Archive Artifacts
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # https://github.com/actions/upload-artifact v4.4.3
+        with:
+           name: "artifacts"
+           path: artifacts
+
+      - name: Release
+        uses: softprops/action-gh-release@72f2c25fcb47643c292f7107632f7a47c1df5cd8 # https://github.com/softprops/action-gh-release v2.3.2
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: |
+            *.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # https://github.com/actions/checkout v4.2.2
 
       - name: Build Artifacts
-        run: cmd.exe /c '.\scripts\make-artifacts.bat'
+        run: cmd.exe /c '.\scripts\make-artifacts.bat' ${{ github.ref_name }}
 
       - name: Archive Artifacts
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # https://github.com/actions/upload-artifact v4.4.3

--- a/scripts/clean.bat
+++ b/scripts/clean.bat
@@ -7,7 +7,9 @@ for /F "delims=#" %%E in ('"prompt #$E# & for %%E in (1) do rem"') do set "_ESC=
 rmdir /s /q x64 2>nul
 rmdir /s /q .vs 2>nul
 rmdir /s /q minimal_gl 2>nul
+rmdir /s /q artifacts 2>nul
 
+del *.zip 2>nul
 del *.vcxproj.user 2>nul
 
 echo %_ESC%[2K %~n0 : Status =%_ESC%[92m OK %_ESC%[0m

--- a/scripts/make-artifacts.bat
+++ b/scripts/make-artifacts.bat
@@ -1,28 +1,32 @@
 @echo off && setlocal EnableDelayedExpansion
 for /F "delims=#" %%E in ('"prompt #$E# & for %%E in (1) do rem"') do set "_ESC=%%E"
 
-call "%~dp0build.bat" || goto :ERROR
-
-if exist "artifacts" ( rmdir /S /Q artifacts 2>nul )
-mkdir     artifacts                                     || goto :ERROR
-mkdir     artifacts\examples                            || goto :ERROR
-copy x64\Release\minimal_gl.exe artifacts\              || goto :ERROR
-copy examples\*.*               artifacts\examples      || goto :ERROR
-
 for /f "tokens=2 delims==" %%a in ('wmic OS Get localdatetime /value') do set "dt=%%a"
 set "YYYY=%dt:~0,4%" & set "MM=%dt:~4,2%" & set "DD=%dt:~6,2%"
 set "Hour=%dt:~8,2%" & set "Min=%dt:~10,2%" & set "Sec=%dt:~12,2%"
-set "build_suffix=build_!YYYY!_!MM!_!DD!"
-set "arcname=minimal_gl.!build_suffix!.zip"
-
-tar.exe -a -cf !arcname! -C artifacts minimal_gl.exe examples || goto :ERROR
+set _=set /a _LINE_NUMBER+=1
+set /a _LINE_NUMBER =9
+!_!
+!_!&& call "%~dp0build.bat" || goto :ERROR
+!_!
+!_!&& if exist "artifacts" ( rmdir /S /Q artifacts 2>nul )
+!_!&& mkdir     artifacts                                     || goto :ERROR
+!_!&& mkdir     artifacts\examples                            || goto :ERROR
+!_!&& copy x64\Release\minimal_gl.exe artifacts\              || goto :ERROR
+!_!&& copy examples\*.*               artifacts\examples      || goto :ERROR
+!_!
+!_!&& set "TAG_NAME=%~1"
+!_!&& if "!TAG_NAME!" == "" ( set "TAG_NAME=build_!YYYY!_!MM!_!DD!" )
+!_!&& set "arcname=minimal_gl.!TAG_NAME!.zip"
+!_!
+!_!&& tar.exe -a -cf !arcname! -C artifacts minimal_gl.exe examples || goto :ERROR
 
 echo !_ESC![2K %~n0 : Status =!_ESC![92m OK !_ESC![0m
 set /a errorno=0
 goto :END
 
 :ERROR
-echo !_ESC![2K %~n0 : Status =!_ESC![92m ERROR !_ESC![0m, _P=!_P!, _E=!_E!
+echo !_ESC![2K %~n0 : Status =!_ESC![92m ERROR !_ESC![0m, Line Number=!_LINE_NUMBER!
 
 :END
 exit /B %errorno%

--- a/scripts/make-artifacts.bat
+++ b/scripts/make-artifacts.bat
@@ -1,0 +1,28 @@
+@echo off && setlocal EnableDelayedExpansion
+for /F "delims=#" %%E in ('"prompt #$E# & for %%E in (1) do rem"') do set "_ESC=%%E"
+
+call "%~dp0build.bat" || goto :ERROR
+
+if exist "artifacts" ( rmdir /S /Q artifacts 2>nul )
+mkdir     artifacts                                     || goto :ERROR
+mkdir     artifacts\examples                            || goto :ERROR
+copy x64\Release\minimal_gl.exe artifacts\              || goto :ERROR
+copy examples\*.*               artifacts\examples      || goto :ERROR
+
+for /f "tokens=2 delims==" %%a in ('wmic OS Get localdatetime /value') do set "dt=%%a"
+set "YYYY=%dt:~0,4%" & set "MM=%dt:~4,2%" & set "DD=%dt:~6,2%"
+set "Hour=%dt:~8,2%" & set "Min=%dt:~10,2%" & set "Sec=%dt:~12,2%"
+set "build_suffix=build_!YYYY!_!MM!_!DD!"
+set "arcname=minimal_gl.!build_suffix!.zip"
+
+tar.exe -a -cf !arcname! -C artifacts minimal_gl.exe examples || goto :ERROR
+
+echo !_ESC![2K %~n0 : Status =!_ESC![92m OK !_ESC![0m
+set /a errorno=0
+goto :END
+
+:ERROR
+echo !_ESC![2K %~n0 : Status =!_ESC![92m ERROR !_ESC![0m, _P=!_P!, _E=!_E!
+
+:END
+exit /B %errorno%


### PR DESCRIPTION
push操作、tag追加操作時に、GitHub-Actions を用いて自動的にアーカイブを生成します。

リポジトリへの push 操作時
--------------------------

リポジトリへの push 操作が行われると、 `.\scripts\make-artifact-archive.bat` を実行し、 `artifacts/` 下のファイル・ディレクトリツリーをアーティファクトとして保存します
- アーティファクト出力例 : https://github.com/t-mat/minimal_gl/actions/runs/17510347137
  - 画面下部「artifacts」の右側のダウンロードボタンからアーティファクトをダウンロードできます
- マージ後は、https://github.com/yosshin4004/minimal_gl/ > Actions タブ > ログ内から任意のエントリを選択 > 画面下部の「artifacts」右側のダウンロードボタン「↓」からダウンロード可能になります
- このアーティファクトは一定期間後に自動的に削除されます


リポジトリへのタグ追加後の push 操作時
--------------------------------------

タグが付与されると、付与されたコミットに対するアーティファクトを生成し、リリース用に永続的に保持します。
また、 github の Releases ページ内の対応するタグに、永続化されたアーカイブへのリンクが追加されます。

- タグの例 : https://github.com/t-mat/minimal_gl/releases/tag/tag-test-2025-09-06-1434
  - `minimal_gl.tag-test-2025-09-06-1434.zip` が永続化されたアーティファクトです
- アーカイブ名は `minimal_gl.<タグ名>.zip` となります
